### PR TITLE
Fix typo in word deleted in .placeholder

### DIFF
--- a/tests/.placeholder
+++ b/tests/.placeholder
@@ -1,1 +1,1 @@
-Write your test in this directory. This file can be deteled.
+Write your test in this directory. This file can be deleted.


### PR DESCRIPTION
Corrected the word "deteled" in the .placeholder file to be "deleted"