### PR TITLE
Add question on copyright year

### DIFF
--- a/meta/common/licensing.yml
+++ b/meta/common/licensing.yml
@@ -6,6 +6,11 @@ copyright_holder:
         {{ owner }}
     help: Copyright holder
 
+copyright_year:
+    type: int
+    default: "{{ now().year }}"
+    help: Copyright year
+
 software_license:
   default: MIT License
   choices:

--- a/meta/common/licensing.yml
+++ b/meta/common/licensing.yml
@@ -8,7 +8,7 @@ copyright_holder:
 
 copyright_year:
     type: int
-    default: "{{ now().year }}"
+    default: "{{ '%Y' | strftime }}"
     help: Copyright year
 
 software_license:


### PR DESCRIPTION
There were already `{{ copyright_year }}` placeholders in certain license files but no variables called `copyright_year`. So the copyright year was not shown in the final project.

I added a question on the copyright year with the default being the current year.