### PR TITLE
Add missing bracket to GPLv2 license text

### DIFF
--- a/meta/template/includes/licenses/{{ "GNU General Public License v2 (GPLv2).jinja" }}
+++ b/meta/template/includes/licenses/{{ "GNU General Public License v2 (GPLv2).jinja" }}
@@ -1,4 +1,4 @@
-      Copyright (Cc {{copyright_year}}  {{copyright_holder}}
+      Copyright (C) {{copyright_year}}  {{copyright_holder}}
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
In the first line of the GPLv2 license file "Copyright (Cc", a typo, was changed to "Copyright (C)"